### PR TITLE
Backports UIHostingConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Environment:
 
 ## Backports
 
+**SwiftUI**
+
 - `AsyncImage`
 - `AppStorage`
 - `background` – ViewBuilder API
@@ -78,6 +80,10 @@ Environment:
 - `StateObject`
 - `Section(_ header:)`
 - `task` – async/await modifier
+
+**UIKit**
+
+- `UIHostingConfiguration` – simplifies embedding SwiftUI in `UICollectionViewCell`'s
 
 ## Extras
 

--- a/Sources/SwiftUIBackports/Backport.swift
+++ b/Sources/SwiftUIBackports/Backport.swift
@@ -1,17 +1,61 @@
 import SwiftUI
+import ObjectiveC
 
+/// Provides a convenient method for backporting API,
+/// including types, functions, properties, property wrappers and more.
+///
+/// To backport a SwiftUI Label for example, you could apply the
+/// following extension:
+///
+///     extension Backport where Content == Any {
+///         public struct Label<Title, Icon> { }
+///     }
+///
+/// Now if we want to provide further extensions to our backport type,
+/// we need to ensure we retain the `Content == Any` generic requirement:
+///
+///     extension Backport.Label where Content == Any, Title == Text, Icon == Image {
+///         public init<S: StringProtocol>(_ title: S, systemName: String) { }
+///     }
+///
+/// In addition to types, we can also provide backports for properties
+/// and methods:
+///
+///     extension Backport.Label where Content: View {
+///         func onChange<Value: Equatable>(of value: Value, perform action: (Value) -> Void) -> some View {
+///             // `content` provides access to the extended type
+///             content.modifier(OnChangeModifier(value, action))
+///         }
+///     }
+///
 public struct Backport<Content> {
-    let content: Content
 
+    /// The underlying content this backport represents.
+    public let content: Content
+
+    /// Initializes a new Backport for the specified content.
+    /// - Parameter content: The content (type) that's being backported
     public init(_ content: Content) {
         self.content = content
     }
+
 }
 
 public extension View {
+    /// Wraps a SwiftUI `View` that can be extended to provide backport functionality.
     var backport: Backport<Self> { .init(self) }
 }
 
 public extension NSObjectProtocol {
-    var backport: Backport<Self> { Backport(self) }
+    /// Wraps an `NSObject` that can be extended to provide backport functionality.
+    ///
+    /// Since these types generally have reference semantics, this implementation provides
+    /// a mutable `Backport` to allow for usage in more broader contexts.
+    ///
+    ///     cell.backport.contentConfiguration = Backport.UIHostingConfiguration { }
+    ///
+    var backport: Backport<Self> {
+        get { objc_getAssociatedObject(self, #function) as? Backport<Self> ?? Backport(self) }
+        set { objc_setAssociatedObject(self, #function, newValue, .OBJC_ASSOCIATION_RETAIN) }
+    }
 }

--- a/Sources/SwiftUIBackports/Internal/SafeArea.swift
+++ b/Sources/SwiftUIBackports/Internal/SafeArea.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/*
+ Since UICollectionView is not designed to support SwiftUI out of the box,
+ we need to use a little trick to get the SwiftUI View's to ignore safeArea
+ insets, otherwise our cell's will not always layout correctly.
+ */
+internal extension UIHostingController {
+    convenience public init(rootView: Content, ignoreSafeArea: Bool) {
+        self.init(rootView: rootView)
+
+        if ignoreSafeArea {
+            disableSafeArea()
+        }
+    }
+
+    func disableSafeArea() {
+        guard let viewClass = object_getClass(view) else { return }
+
+        let viewSubclassName = String(cString: class_getName(viewClass)).appending("_IgnoreSafeArea")
+        if let viewSubclass = NSClassFromString(viewSubclassName) {
+            object_setClass(view, viewSubclass)
+        }
+        else {
+            guard let viewClassNameUtf8 = (viewSubclassName as NSString).utf8String else { return }
+            guard let viewSubclass = objc_allocateClassPair(viewClass, viewClassNameUtf8, 0) else { return }
+
+            if let method = class_getInstanceMethod(UIView.self, #selector(getter: UIView.safeAreaInsets)) {
+                let safeAreaInsets: @convention(block) (AnyObject) -> UIEdgeInsets = { _ in
+                    return .zero
+                }
+                class_addMethod(viewSubclass, #selector(getter: UIView.safeAreaInsets), imp_implementationWithBlock(safeAreaInsets), method_getTypeEncoding(method))
+            }
+
+            objc_registerClassPair(viewSubclass)
+            object_setClass(view, viewSubclass)
+        }
+    }
+}

--- a/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/Cells/UICollectionViewCell.swift
+++ b/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/Cells/UICollectionViewCell.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import ObjectiveC
+
+@available(iOS, deprecated: 14)
+@available(tvOS, deprecated: 14)
+@available(macOS, unavailable)
+@available(watchOS, unavailable)
+extension Backport where Content: UICollectionViewCell {
+
+    private var configuredView: UIView? {
+        get { objc_getAssociatedObject(self, #function) as? UIView }
+        set { objc_setAssociatedObject(self, #function, newValue, .OBJC_ASSOCIATION_ASSIGN) }
+    }
+
+    /// The current content configuration of the cell.
+    ///
+    /// Setting a content configuration replaces the existing contentView of the
+    /// cell with a new content view instance from the configuration.
+    public var contentConfiguration: BackportUIContentConfiguration? {
+        get { objc_getAssociatedObject(self, #function) as? BackportUIContentConfiguration }
+        set {
+            objc_setAssociatedObject(self, #function, newValue, .OBJC_ASSOCIATION_RETAIN)
+            configuredView?.removeFromSuperview()
+
+            guard let configuration = newValue else { return }
+            let contentView = content.contentView
+
+            let configuredView = configuration.makeContentView()
+            configuredView.translatesAutoresizingMaskIntoConstraints = false
+
+            content.clipsToBounds = false
+            contentView.clipsToBounds = false
+            content.preservesSuperviewLayoutMargins = false
+            contentView.addSubview(configuredView)
+
+            let insets = Mirror(reflecting: configuration)
+                .children.first(where: { $0.label == "insets" })?.value as? ProposedInsets
+            ?? .unspecified
+
+            insets.top.flatMap { contentView.directionalLayoutMargins.top = $0 }
+            insets.bottom.flatMap { contentView.directionalLayoutMargins.bottom = $0 }
+            insets.leading.flatMap { contentView.directionalLayoutMargins.leading = $0 }
+            insets.trailing.flatMap { contentView.directionalLayoutMargins.trailing = $0 }
+
+            NSLayoutConstraint.activate([
+                configuredView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+                configuredView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+                configuredView.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
+                configuredView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            ])
+
+            var background: AnyView? {
+                Mirror(reflecting: configuration)
+                    .children.first(where: { $0.label == "background" })?.value as? AnyView
+            }
+
+            background.flatMap {
+                let host = UIHostingController(rootView: $0, ignoreSafeArea: true)
+                content.backgroundView = host.view
+            }
+
+            background.flatMap {
+                let host = UIHostingController(rootView: $0, ignoreSafeArea: true)
+                content.selectedBackgroundView = host.view
+            }
+
+            self.configuredView = configuredView
+        }
+    }
+
+}

--- a/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/Cells/UICollectionViewCell.swift
+++ b/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/Cells/UICollectionViewCell.swift
@@ -17,9 +17,8 @@ extension Backport where Content: UICollectionViewCell {
     /// Setting a content configuration replaces the existing contentView of the
     /// cell with a new content view instance from the configuration.
     public var contentConfiguration: BackportUIContentConfiguration? {
-        get { objc_getAssociatedObject(self, #function) as? BackportUIContentConfiguration }
+        get { nil } // we can't really support anything here, so for now we'll return nil
         set {
-            objc_setAssociatedObject(self, #function, newValue, .OBJC_ASSOCIATION_RETAIN)
             configuredView?.removeFromSuperview()
 
             guard let configuration = newValue else { return }

--- a/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/Cells/UICollectionViewCell.swift
+++ b/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/Cells/UICollectionViewCell.swift
@@ -30,7 +30,7 @@ extension Backport where Content: UICollectionViewCell {
 
             content.clipsToBounds = false
             contentView.clipsToBounds = false
-            content.preservesSuperviewLayoutMargins = false
+            contentView.preservesSuperviewLayoutMargins = false
             contentView.addSubview(configuredView)
 
             let insets = Mirror(reflecting: configuration)

--- a/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/ProposedInsets.swift
+++ b/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/ProposedInsets.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Provides optional inset values. `nil` is interpreted as: use system default
+internal struct ProposedInsets: Equatable {
+
+    /// The proposed leading margin measured in points.
+    ///
+    /// A value of `nil` tells the system to use a default value
+    public var leading: CGFloat?
+
+    /// The proposed trailing margin measured in points.
+    ///
+    /// A value of `nil` tells the system to use a default value
+    public var trailing: CGFloat?
+
+    /// The proposed top margin measured in points.
+    ///
+    /// A value of `nil` tells the system to use a default value
+    public var top: CGFloat?
+
+    /// The proposed bottom margin measured in points.
+    ///
+    /// A value of `nil` tells the system to use a default value
+    public var bottom: CGFloat?
+
+    /// An insets proposal with all dimensions left unspecified.
+    public static var unspecified: ProposedInsets { .init() }
+
+    /// An insets proposal that contains zero for all dimensions.
+    public static var zero: ProposedInsets { .init(leading: 0, trailing: 0, top: 0, bottom: 0) }
+
+}

--- a/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/ProposedSize.swift
+++ b/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/ProposedSize.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// A proposal for the size
+///
+/// * The ``zero`` proposal; the size responds with its minimum size.
+/// * The ``infinity`` proposal; the size responds with its maximum size.
+/// * The ``unspecified`` proposal; the size responds with its system default size.
+internal struct ProposedSize: Equatable, Sendable {
+
+    /// The proposed horizontal size measured in points.
+    ///
+    /// A value of `nil` represents an unspecified width proposal.
+    public var width: CGFloat?
+
+    /// The proposed vertical size measured in points.
+    ///
+    /// A value of `nil` represents an unspecified height proposal.
+    public var height: CGFloat?
+
+    /// A size proposal that contains zero in both dimensions.
+    public static var zero: ProposedSize { .init(width: 0, height: 0) }
+
+    /// The proposed size with both dimensions left unspecified.
+    ///
+    /// Both dimensions contain `nil` in this size proposal.
+    public static var unspecified: ProposedSize { .init(width: nil, height: nil) }
+
+    /// A size proposal that contains infinity in both dimensions.
+    ///
+    /// Both dimensions contain .infinity in this size proposal.
+    public static var infinity: ProposedSize { .init(width: .infinity, height: .infinity) }
+
+    /// Creates a new proposed size using the specified width and height.
+    ///
+    /// - Parameters:
+    ///   - width: A proposed width in points. Use a value of `nil` to indicate
+    ///     that the width is unspecified for this proposal.
+    ///   - height: A proposed height in points. Use a value of `nil` to
+    ///     indicate that the height is unspecified for this proposal.
+    @inlinable public init(width: CGFloat?, height: CGFloat?) {
+        self.width = width
+        self.height = height
+    }
+
+    /// Creates a new proposed size from a specified size.
+    ///
+    /// - Parameter size: A proposed size with dimensions measured in points.
+    @inlinable public init(_ size: CGSize) {
+        self.width = size.width
+        self.height = size.height
+    }
+
+}

--- a/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/UIContentConfiguration.swift
+++ b/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/UIContentConfiguration.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/// The requirements for an object that provides the configuration for a content view.
+///
+/// This protocol provides a blueprint for a content configuration object, which encompasses
+/// default styling and content for a content view. The content configuration encapsulates
+/// all of the supported properties and behaviors for content view customization.
+/// You use the configuration to create the content view.
+@available(iOS, deprecated: 14)
+@available(tvOS, deprecated: 14)
+@available(macOS, unavailable)
+@available(watchOS, unavailable)
+public protocol BackportUIContentConfiguration {
+    /// Initializes and returns a new instance of the content view using this configuration.
+    func makeContentView() -> UIView
+}

--- a/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/UIHostingConfiguration.swift
+++ b/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/UIHostingConfiguration.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+@available(iOS, deprecated: 16)
+@available(tvOS, deprecated: 16)
+@available(macOS, unavailable)
+@available(watchOS, unavailable)
+extension Backport where Content == Any {
+
+    public struct UIHostingConfiguration<Label, Background>: BackportUIContentConfiguration where Label: View, Background: View {
+
+        var content: Label
+        var background: AnyView?
+        var insets: ProposedInsets
+        var minSize: ProposedSize
+
+        /// Sets the background contents for the hosting configuration's enclosing
+        /// cell.
+        ///
+        /// The following example sets a custom view to the background of the cell:
+        ///
+        ///     UIHostingConfiguration {
+        ///         Text("My Contents")
+        ///     }
+        ///     .background {
+        ///         MyBackgroundView()
+        ///     }
+        ///
+        /// - Parameter background: The contents of the SwiftUI hierarchy to be
+        ///   shown inside the background of the cell.
+        public func background<B>(@ViewBuilder background: () -> B) -> Backport.UIHostingConfiguration<Label, B> where B: View {
+            .init(content: self.content, background: AnyView(background()), insets: insets, minSize: minSize)
+        }
+
+        /// Sets the background contents for the hosting configuration's enclosing
+        /// cell.
+        ///
+        /// The following example sets a custom view to the background of the cell:
+        ///
+        ///     UIHostingConfiguration {
+        ///         Text("My Contents")
+        ///     }
+        ///     .background(Color.blue)
+        ///
+        /// - Parameter style: The shape style to be used as the background of the
+        ///   cell.
+        public func background<S>(_ style: S) -> Backport.UIHostingConfiguration<Label, S> where S: ShapeStyle {
+            .init(content: self.content, background: AnyView(style), insets: insets, minSize: minSize)
+        }
+
+        /// Initializes and returns a new instance of the content view using this configuration.
+        public func makeContentView() -> UIView {
+            let view = UIHostingController(
+                rootView: ZStack {
+                    background
+                    content
+                },
+                ignoreSafeArea: true
+            ).view!
+
+            view.backgroundColor = .clear
+            view.clipsToBounds = false
+
+            return view
+        }
+
+    }
+    
+}
+
+extension Backport.UIHostingConfiguration {
+
+    /// Sets the margins around the content of the configuration.
+    ///
+    /// Use this modifier to replace the default margins applied to the root of
+    /// the configuration. The following example creates 20 points of space
+    /// between the content and the background on the horizontal edges.
+    ///
+    ///     UIHostingConfiguration {
+    ///         Text("My Contents")
+    ///     }
+    ///     .margins(.horizontal, 20.0)
+    ///
+    /// - Parameters:
+    ///    - edges: The edges to apply the insets. Any edges not specified will
+    ///      use the system default values. The default value is
+    ///      ``Edge/Set/all``.
+    ///    - length: The amount to apply.
+    public func margins(_ edges: Edge.Set = .all, _ length: CGFloat) -> Self {
+        var view = self
+        if edges.contains(.leading) { view.insets.leading = length }
+        if edges.contains(.trailing) { view.insets.trailing = length }
+        if edges.contains(.top) { view.insets.top = length }
+        if edges.contains(.bottom) { view.insets.bottom = length }
+        return view
+    }
+
+    /// Sets the margins around the content of the configuration.
+    ///
+    /// Use this modifier to replace the default margins applied to the root of
+    /// the configuration. The following example creates 10 points of space
+    /// between the content and the background on the leading edge and 20 points
+    /// of space on the trailing edge:
+    ///
+    ///     UIHostingConfiguration {
+    ///         Text("My Contents")
+    ///     }
+    ///     .margins(.horizontal, 20.0)
+    ///
+    /// - Parameters:
+    ///    - edges: The edges to apply the insets. Any edges not specified will
+    ///      use the system default values. The default value is
+    ///      ``Edge/Set/all``.
+    ///    - insets: The insets to apply.
+    public func margins(_ edges: Edge.Set = .all, _ insets: EdgeInsets) -> Self {
+        var view = self
+        if edges.contains(.leading) { view.insets.leading = insets.leading }
+        if edges.contains(.trailing) { view.insets.trailing = insets.trailing }
+        if edges.contains(.top) { view.insets.top = insets.top }
+        if edges.contains(.bottom) { view.insets.bottom = insets.bottom }
+        return view
+    }
+
+    /// Sets the minimum size for the configuration.
+    ///
+    /// Use this modifier to indicate that a configuration's associated cell can
+    /// be resized to a specific minimum. The following example allows the cell
+    /// to be compressed to zero size:
+    ///
+    ///     UIHostingConfiguration {
+    ///         Text("My Contents")
+    ///     }
+    ///     .minSize(width: 0, height: 0)
+    ///
+    /// - Parameter width: The value to use for the width dimension. A value of
+    ///   `nil` indicates that the system default should be used.
+    /// - Parameter height: The value to use for the height dimension. A value
+    ///   of `nil` indicates that the system default should be used.
+//    public func minSize(width: CGFloat? = nil, height: CGFloat? = nil) -> Self {
+//        var view = self
+//        view.minSize = .init(width: width, height: height)
+//        return view
+//    }
+
+}
+
+@available(iOS, deprecated: 16)
+@available(tvOS, deprecated: 16)
+@available(macOS, unavailable)
+@available(watchOS, unavailable)
+extension Backport.UIHostingConfiguration where Content == Any, Background == EmptyView {
+
+    /// Creates a hosting configuration with the given contents.
+    ///
+    /// - Parameter content: The contents of the SwiftUI hierarchy to be shown
+    ///   inside the cell.
+    public init(@ViewBuilder content: () -> Label) {
+        self.init(content: content(), background: nil, insets: .init(), minSize: .unspecified)
+    }
+
+}

--- a/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/UIHostingConfiguration.swift
+++ b/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/UIHostingConfiguration.swift
@@ -6,6 +6,31 @@ import SwiftUI
 @available(watchOS, unavailable)
 extension Backport where Content == Any {
 
+    /**
+     A content configuration suitable for hosting a hierarchy of SwiftUI views.
+     Use a value of this type, which conforms to the UIContentConfiguration protocol, with a UICollectionViewCell or UITableViewCell to host a hierarchy of SwiftUI views in a collection or table view, respectively. For example, the following shows a stack with an image and text inside the cell:
+
+         myCell.contentConfiguration = UIHostingConfiguration {
+            HStack {
+                Image(systemName: "star").foregroundStyle(.purple)
+                Text("Favorites")
+                Spacer()
+            }
+         }
+
+     You can also customize the background of the containing cell. The following example draws a blue background:
+
+         myCell.contentConfiguration = UIHostingConfiguration {
+            HStack {
+                Image(systemName: "star").foregroundStyle(.purple)
+                Text("Favorites")
+                Spacer()
+            }
+         }
+         .background {
+            Color.blue
+         }
+     */
     public struct UIHostingConfiguration<Label, Background>: BackportUIContentConfiguration where Label: View, Background: View {
 
         var content: Label


### PR DESCRIPTION
This simplifies embedding SwiftUI view's in `UICollectionViewCell`'s. 

> `UITableViewCell` will come in a future update.

Note: Some features were intentionally omitted as they were not relevant for a backport and would require a substantial effort to include. However, I believe this implementation satisfies the majority of cases.

In-app testing and user-feedback will be required in order to fix any (currently unknown) bugs.