### PR TITLE
Fix typo in logged warning

### DIFF
--- a/Sources/SwiftUIBackports/Internal/Environment+String.swift
+++ b/Sources/SwiftUIBackports/Internal/Environment+String.swift
@@ -44,7 +44,7 @@ private extension EnvironmentValues {
             let rest = typeName.dropFirst(expectedPrefix.count)
             let expectedSuffix = ">>"
             guard rest.hasSuffix(expectedSuffix) else {
-                print("Wrong prefix")
+                print("Wrong suffix")
                 return nil
             }
             let middle = rest.dropLast(expectedSuffix.count)


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/shaps80/.github/blob/master/CONTRIBUTING.md)?*

Issue #

## Describe your changes

The printed warning describes the wrong problem. As it is checking the suffix on this guard statement, not the prefix.
