### PR TITLE
Fix typo in documentation

### DIFF
--- a/Sources/SwiftUIBackports/iOS/PresentationDetents/Detents.swift
+++ b/Sources/SwiftUIBackports/iOS/PresentationDetents/Detents.swift
@@ -25,7 +25,7 @@ public extension Backport where Wrapped: View {
     ///     }
     ///
     /// - Parameter detents: A set of supported detents for the sheet.
-    ///   If you provide more that one detent, people can drag the sheet
+    ///   If you provide more than one detent, people can drag the sheet
     ///   to resize it.
     @ViewBuilder
     func presentationDetents(_ detents: Set<Backport<Any>.PresentationDetent>) -> some View {


### PR DESCRIPTION
Incorrect word is used in the description of the parameter.