### PR TITLE
Fix configuredView doesn’t removed from cell when reuse

### DIFF
--- a/Sources/SwiftUIBackports/Backport.swift
+++ b/Sources/SwiftUIBackports/Backport.swift
@@ -48,14 +48,5 @@ public extension View {
 
 public extension NSObjectProtocol {
     /// Wraps an `NSObject` that can be extended to provide backport functionality.
-    ///
-    /// Since these types generally have reference semantics, this implementation provides
-    /// a mutable `Backport` to allow for usage in more broader contexts.
-    ///
-    ///     cell.backport.contentConfiguration = Backport.UIHostingConfiguration { }
-    ///
-    var backport: Backport<Self> {
-        get { objc_getAssociatedObject(self, #function) as? Backport<Self> ?? Backport(self) }
-        set { objc_setAssociatedObject(self, #function, newValue, .OBJC_ASSOCIATION_RETAIN) }
-    }
+    var backport: Backport<Self> { .init(self) }
 }

--- a/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/Cells/UICollectionViewCell.swift
+++ b/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/Cells/UICollectionViewCell.swift
@@ -2,16 +2,22 @@ import SwiftUI
 import ObjectiveC
 
 #if os(iOS) || os(tvOS)
+
+extension UICollectionViewCell {
+    
+    private static var configuredViewAssociatedKey: Void?
+    
+    fileprivate var configuredView: UIView? {
+        get { objc_getAssociatedObject(self, &Self.configuredViewAssociatedKey) as? UIView }
+        set { objc_setAssociatedObject(self, &Self.configuredViewAssociatedKey, newValue, .OBJC_ASSOCIATION_ASSIGN) }
+    }
+}
+
 @available(iOS, deprecated: 14)
 @available(tvOS, deprecated: 14)
 @available(macOS, unavailable)
 @available(watchOS, unavailable)
 extension Backport where Wrapped: UICollectionViewCell {
-
-    private var configuredView: UIView? {
-        get { objc_getAssociatedObject(self, #function) as? UIView }
-        set { objc_setAssociatedObject(self, #function, newValue, .OBJC_ASSOCIATION_ASSIGN) }
-    }
 
     /// The current content configuration of the cell.
     ///
@@ -19,8 +25,8 @@ extension Backport where Wrapped: UICollectionViewCell {
     /// cell with a new content view instance from the configuration.
     public var contentConfiguration: BackportUIContentConfiguration? {
         get { nil } // we can't really support anything here, so for now we'll return nil
-        set {
-            configuredView?.removeFromSuperview()
+        nonmutating set {
+            content.configuredView?.removeFromSuperview()
 
             guard let configuration = newValue else { return }
             let contentView = content.contentView
@@ -64,7 +70,7 @@ extension Backport where Wrapped: UICollectionViewCell {
                 content.selectedBackgroundView = host.view
             }
 
-            self.configuredView = configuredView
+            content.configuredView = configuredView
         }
     }
 

--- a/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/Cells/UITableViewCell.swift
+++ b/Sources/SwiftUIBackports/iOS/UIHostingConfiguration/Cells/UITableViewCell.swift
@@ -2,16 +2,22 @@ import SwiftUI
 import ObjectiveC
 
 #if os(iOS) || os(tvOS)
+
+extension UITableViewCell {
+    
+    private static var configuredViewAssociatedKey: Void?
+    
+    fileprivate var configuredView: UIView? {
+        get { objc_getAssociatedObject(self, &Self.configuredViewAssociatedKey) as? UIView }
+        set { objc_setAssociatedObject(self, &Self.configuredViewAssociatedKey, newValue, .OBJC_ASSOCIATION_ASSIGN) }
+    }
+}
+
 @available(iOS, deprecated: 14)
 @available(tvOS, deprecated: 14)
 @available(macOS, unavailable)
 @available(watchOS, unavailable)
 extension Backport where Wrapped: UITableViewCell {
-
-    private var configuredView: UIView? {
-        get { objc_getAssociatedObject(self, #function) as? UIView }
-        set { objc_setAssociatedObject(self, #function, newValue, .OBJC_ASSOCIATION_ASSIGN) }
-    }
 
     /// The current content configuration of the cell.
     ///
@@ -19,8 +25,8 @@ extension Backport where Wrapped: UITableViewCell {
     /// cell with a new content view instance from the configuration.
     public var contentConfiguration: BackportUIContentConfiguration? {
         get { nil } // we can't really support anything here, so for now we'll return nil
-        set {
-            configuredView?.removeFromSuperview()
+        nonmutating set {
+            content.configuredView?.removeFromSuperview()
 
             guard let configuration = newValue else { return }
             let contentView = content.contentView
@@ -64,7 +70,7 @@ extension Backport where Wrapped: UITableViewCell {
                 content.selectedBackgroundView = host.view
             }
 
-            self.configuredView = configuredView
+            content.configuredView = configuredView
         }
     }
 


### PR DESCRIPTION
Issue #

## Describe your changes

The configuredView never removed from cell so it created and add to cell many many times when scroll,

the reasons:
* the key `#function` is different between `get` and `set`
 ```
(lldb) po #function
"$__lldb_wrapped_expr_10(_:)"

(lldb) po #function
"$__lldb_wrapped_expr_12(_:)"
```
* Backport as a value type can not store value by `objc_setAssociatedObject`