### PR TITLE
Push Transition

### DIFF
--- a/Sources/SwiftUIBackports/Backport.swift
+++ b/Sources/SwiftUIBackports/Backport.swift
@@ -50,3 +50,10 @@ public extension NSObjectProtocol {
     /// Wraps an `NSObject` that can be extended to provide backport functionality.
     var backport: Backport<Self> { .init(self) }
 }
+
+public extension AnyTransition {
+    /// Wraps an `AnyTransition` that can be extended to provide backport functionality.
+    static var backport: Backport<AnyTransition>{
+        Backport(.identity)
+    }
+}

--- a/Sources/SwiftUIBackports/Shared/Transition/PushTransition.swift
+++ b/Sources/SwiftUIBackports/Shared/Transition/PushTransition.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  PushTransition.swift
 //  
 //
 //  Created by Andrey Plotnikov on 10.08.2022.

--- a/Sources/SwiftUIBackports/Shared/Transition/PushTransition.swift
+++ b/Sources/SwiftUIBackports/Shared/Transition/PushTransition.swift
@@ -8,7 +8,12 @@
 import SwiftUI
 
 extension AnyTransition {
-    
+    static var backport: Backport<AnyTransition>{
+        Backport(.identity)
+    }
+}
+
+extension Backport where Wrapped == AnyTransition {
     /// Creates a transition that when added to a view will animate the view’s insertion by moving it in from the specified edge while fading it in, and animate its removal by moving it out towards the opposite edge and fading it out.
     /// - Parameter edge: the edge from which the view will be animated in.
     /// - Returns: A transition that animates a view by moving and fading it.
@@ -17,7 +22,7 @@ extension AnyTransition {
     @available(macOS, deprecated: 13.0)
     @available(tvOS, deprecated: 16.0)
     @available(macCatalyst, deprecated: 16.0)
-    static func push(from edge: Edge) -> AnyTransition {
+    func push(from edge: Edge) -> AnyTransition {
         
         var oppositeEdge: Edge
         switch edge {

--- a/Sources/SwiftUIBackports/Shared/Transition/PushTransition.swift
+++ b/Sources/SwiftUIBackports/Shared/Transition/PushTransition.swift
@@ -1,17 +1,4 @@
-//
-//  PushTransition.swift
-//  
-//
-//  Created by Andrey Plotnikov on 10.08.2022.
-//
-
 import SwiftUI
-
-public extension AnyTransition {
-    static var backport: Backport<AnyTransition>{
-        Backport(.identity)
-    }
-}
 
 public extension Backport where Wrapped == AnyTransition {
     /// Creates a transition that when added to a view will animate the view’s insertion by moving it in from the specified edge while fading it in, and animate its removal by moving it out towards the opposite edge and fading it out.
@@ -21,9 +8,7 @@ public extension Backport where Wrapped == AnyTransition {
     @available(watchOS, deprecated: 9.0)
     @available(macOS, deprecated: 13.0)
     @available(tvOS, deprecated: 16.0)
-    @available(macCatalyst, deprecated: 16.0)
     func push(from edge: Edge) -> AnyTransition {
-        
         var oppositeEdge: Edge
         switch edge {
         case .top:
@@ -36,7 +21,10 @@ public extension Backport where Wrapped == AnyTransition {
             oppositeEdge = .leading
         }
             
-        return .asymmetric(insertion: .move(edge: edge), removal: .move(edge: oppositeEdge)).combined(with: .opacity)
+        return .asymmetric(
+            insertion: .move(edge: edge),
+            removal: .move(edge: oppositeEdge)
+        ).combined(with: .opacity)
     }
 }
 

--- a/Sources/SwiftUIBackports/Shared/Transition/PushTransition.swift
+++ b/Sources/SwiftUIBackports/Shared/Transition/PushTransition.swift
@@ -1,0 +1,36 @@
+//
+//  File.swift
+//  
+//
+//  Created by Andrey Plotnikov on 10.08.2022.
+//
+
+import SwiftUI
+
+extension AnyTransition {
+    
+    /// Creates a transition that when added to a view will animate the view’s insertion by moving it in from the specified edge while fading it in, and animate its removal by moving it out towards the opposite edge and fading it out.
+    /// - Parameter edge: the edge from which the view will be animated in.
+    /// - Returns: A transition that animates a view by moving and fading it.
+    @available(iOS, deprecated: 16.0)
+    @available(watchOS, deprecated: 9.0)
+    @available(macOS, deprecated: 13.0)
+    @available(tvOS, deprecated: 16.0)
+    @available(macCatalyst, deprecated: 16.0)
+    static func push(from edge: Edge) -> AnyTransition {
+        
+        var oppositeEdge: Edge
+        switch edge {
+        case .top:
+            oppositeEdge = .bottom
+        case .leading:
+            oppositeEdge = .trailing
+        case .bottom:
+            oppositeEdge = .top
+        case .trailing:
+            oppositeEdge = .leading
+        }
+        
+        return .asymmetric(insertion: .move(edge: edge), removal: .move(edge: oppositeEdge)).combined(with: .opacity)
+    }
+}

--- a/Sources/SwiftUIBackports/Shared/Transition/PushTransition.swift
+++ b/Sources/SwiftUIBackports/Shared/Transition/PushTransition.swift
@@ -7,13 +7,13 @@
 
 import SwiftUI
 
-extension AnyTransition {
+public extension AnyTransition {
     static var backport: Backport<AnyTransition>{
         Backport(.identity)
     }
 }
 
-extension Backport where Wrapped == AnyTransition {
+public extension Backport where Wrapped == AnyTransition {
     /// Creates a transition that when added to a view will animate the view’s insertion by moving it in from the specified edge while fading it in, and animate its removal by moving it out towards the opposite edge and fading it out.
     /// - Parameter edge: the edge from which the view will be animated in.
     /// - Returns: A transition that animates a view by moving and fading it.
@@ -35,7 +35,9 @@ extension Backport where Wrapped == AnyTransition {
         case .trailing:
             oppositeEdge = .leading
         }
-        
+            
         return .asymmetric(insertion: .move(edge: edge), removal: .move(edge: oppositeEdge)).combined(with: .opacity)
     }
 }
+
+


### PR DESCRIPTION
## Describe your changes

This pr adds a new push [transition](https://developer.apple.com/documentation/swiftui/anytransition/push(from:)) from SwiftUI 4 lifecycle

- Added func push(from edge: Edge) -> AnyTransition

Question: Is there an example how to add it to Backport?