### PR TITLE
Fix `presentationDetents` order

### DIFF
--- a/Sources/SwiftUIBackports/iOS/PresentationDetents/Detents.swift
+++ b/Sources/SwiftUIBackports/iOS/PresentationDetents/Detents.swift
@@ -93,7 +93,7 @@ public extension Backport where Wrapped: View {
 public extension Backport where Wrapped == Any {
 
     /// A type that represents a height where a sheet naturally rests.
-    struct PresentationDetent: Hashable {
+    struct PresentationDetent: Hashable, Comparable {
 
         public struct Identifier: RawRepresentable, Hashable {
             public var rawValue: String
@@ -127,6 +127,14 @@ public extension Backport where Wrapped == Any {
             return .init(id: .init(rawValue: ""))
         }
 
+        public static func < (lhs: PresentationDetent, rhs: PresentationDetent) -> Bool {
+            switch (lhs, rhs) {
+            case (.large, .medium):
+                return false
+            default:
+                return true
+            }
+        }
     }
 }
 
@@ -182,15 +190,7 @@ private extension Backport.Representable {
 
             if let controller = parent?.sheetPresentationController {
                 controller.animateChanges {
-                    controller.detents = detents.sorted(by: {
-                        switch ($0, $1) {
-                        case (.large, .medium):
-                            return false
-                        default:
-                            return true
-                        }
-                    })
-                    .map {
+                    controller.detents = detents.sorted().map {
                         switch $0 {
                         case .medium:
                             return .medium()

--- a/Sources/SwiftUIBackports/iOS/PresentationDetents/Detents.swift
+++ b/Sources/SwiftUIBackports/iOS/PresentationDetents/Detents.swift
@@ -182,7 +182,15 @@ private extension Backport.Representable {
 
             if let controller = parent?.sheetPresentationController {
                 controller.animateChanges {
-                    controller.detents = detents.map {
+                    controller.detents = detents.sorted(by: {
+                        switch ($0, $1) {
+                        case (.large, .medium):
+                            return false
+                        default:
+                            return true
+                        }
+                    })
+                    .map {
                         switch $0 {
                         case .medium:
                             return .medium()


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/shaps80/.github/blob/master/CONTRIBUTING.md)?*

Yes! 🎉

~~Issue #~~

## Describe your changes

[`UISheetPresentationController.detents`](https://developer.apple.com/documentation/uikit/uisheetpresentationcontroller/3801903-detents) are expected to be ordered:
> When you set this value, specify detents in order from smallest to largest height.

Otherwise, sheets are opened with a random dentent if you provide more than one in SwiftUI, e.g.:
```swift
.backport.presentationDetents([.medium, .large])
```
because detents are forwarded as an unordered `Set` to the underlying `UISheetPresentationController.detents` array for the backport:
```swift
func presentationDetents(_ detents: Set<Backport<Any>.PresentationDetent>) -> some View
```