### PR TITLE
Reset `tintAdjustmentMode` for `presentationUndimmed`

### DIFF
--- a/Sources/SwiftUIBackports/iOS/PresentationDetents/InteractiveDetent.swift
+++ b/Sources/SwiftUIBackports/iOS/PresentationDetents/InteractiveDetent.swift
@@ -82,6 +82,7 @@ private extension Backport.Representable {
                     controller.largestUndimmedDetentIdentifier = identifier.flatMap {
                         .init(rawValue: $0.rawValue)
                     }
+                    controller.presentingViewController.view.tintAdjustmentMode = .normal
                 }
             }
         }


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/shaps80/.github/blob/master/CONTRIBUTING.md)?*

Yes! 🎉

~~Issue #~~

## Describe your changes

As discussed here: https://danielsaidi.com/blog/2022/06/21/undimmed-presentation-detents-in-swiftui
`tintAdjustmentMode` should be set to `.normal` in order to "undimm" the underlying view otherwise it stays dimmed even when the sheet is dismissed (at least in a `NavigationView` context).
