### PR TITLE
Fix typo that causes failing compilation

### DIFF
--- a/Sources/SwiftUIBackports/Shared/Quicklook/Quicklook.swift
+++ b/Sources/SwiftUIBackports/Shared/Quicklook/Quicklook.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-#if canImport(Quicklook)
+#if canImport(QuickLook)
 import QuickLook
 #endif
 


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/shaps80/.github/blob/master/CONTRIBUTING.md)?* Yes

Issue #24

## Describe your changes
 I just fixed a small typo in the code. For some reason this typo causes Xcode 14 RC to not compile a Mac Catalyst App with the error "Redefinition of module 'QuickLook'".