### PR TITLE
Fix presentation of sheet with presentationDetents after rotating the…

### DIFF
--- a/Sources/SwiftUIBackports/iOS/PresentationDetents/Detents.swift
+++ b/Sources/SwiftUIBackports/iOS/PresentationDetents/Detents.swift
@@ -220,6 +220,11 @@ private extension Backport.Representable {
             update(detents: detents, selection: selection, largestUndimmed: largestUndimmed)
         }
 
+        override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+            super.willTransition(to: newCollection, with: coordinator)
+            update(detents: detents, selection: selection, largestUndimmed: largestUndimmed)
+        }
+
         func update(detents: Set<Backport<Any>.PresentationDetent>, selection: Binding<Backport<Any>.PresentationDetent>?, largestUndimmed: Backport<Any>.PresentationDetent?) {
             self.detents = detents
             self.selection = selection
@@ -249,9 +254,9 @@ private extension Backport.Representable {
 
                 UIView.animate(withDuration: 0.25) {
                     if let undimmed = largestUndimmed {
-                        controller.presentingViewController.view.tintAdjustmentMode = (selection?.wrappedValue ?? .large) >= undimmed ? .automatic : .normal
+                        controller.presentingViewController.view?.tintAdjustmentMode = (selection?.wrappedValue ?? .large) >= undimmed ? .automatic : .normal
                     } else {
-                        controller.presentingViewController.view.tintAdjustmentMode = .automatic
+                        controller.presentingViewController.view?.tintAdjustmentMode = .automatic
                     }
                 }
             }

--- a/Sources/SwiftUIBackports/iOS/PresentationDetents/DragIndicator.swift
+++ b/Sources/SwiftUIBackports/iOS/PresentationDetents/DragIndicator.swift
@@ -78,6 +78,11 @@ private extension Backport.Representable {
             update(visibility: visibility)
         }
 
+        override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+            super.willTransition(to: newCollection, with: coordinator)
+            update(visibility: visibility)
+        }
+
         func update(visibility: Backport<Any>.Visibility) {
             self.visibility = visibility
 


### PR DESCRIPTION
… device by adding a call to update() in willTransition()

*Have you read the [Contributing Guidelines](https://github.com/shaps80/.github/blob/master/CONTRIBUTING.md)?*

Yes

Issue #36 

## Describe your changes

Just added the needed `willTransition` callbacks to update the sheet presentation when the device rotates.
