### PR TITLE
Added navigation ToolbarItemPlacement

### DIFF
--- a/Sources/SwiftUIBackports/Shared/Toolbar/Toolbar.swift
+++ b/Sources/SwiftUIBackports/Shared/Toolbar/Toolbar.swift
@@ -12,10 +12,11 @@ public extension Backport<Any> {
         case destructiveAction
         case principal
         case bottomBar
+        case navigation
 
         var isLeading: Bool {
             switch self {
-            case .cancellationAction:
+            case .cancellationAction, .navigation:
                 return true
             default:
                 return false


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/shaps80/.github/blob/master/CONTRIBUTING.md)?*

Yes

## Describe your changes

iOS 14.0 added the [navigation](https://developer.apple.com/documentation/swiftui/toolbaritemplacement/navigation) `ToolbarItemPlacement` type:

>In macOS and in Mac Catalyst apps, the system places navigation items in the leading edge of the toolbar ahead of the inline title if that is present in the toolbar.
> In iOS, iPadOS, and tvOS, navigation items appear in the leading edge of the navigation bar. If a system navigation item such as a back button is present in a compact width, it instead appears in the [primaryAction](https://developer.apple.com/documentation/swiftui/toolbaritemplacement/primaryaction) placement.

This is a straightforward change - most of the work is already done. This just adds a `navigation` value to the `ToolbarItemPlacement` enum, then ensures it's added to the leading side of the navigation bar.