### PR TITLE
Removes the unused namespace property

### DIFF
--- a/Sources/SwiftUIBackports/Shared/Toolbar/Toolbar.swift
+++ b/Sources/SwiftUIBackports/Shared/Toolbar/Toolbar.swift
@@ -119,8 +119,6 @@ struct ToolbarModifier: ViewModifier {
         }
     }
 
-    @Namespace private var namespace
-
     func body(content: Content) -> some View {
         content
             .navigationBarItems(leading: leading, trailing: trailing)


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/shaps80/.github/blob/master/CONTRIBUTING.md)?*

Issue #42 

## Describe your changes

Removes the `@Namespace` property in Toolbar.swift, as it is unused and causes a compilation error on Xcode 14.3.
This fixes it, and allows the project to compile again.