### PR TITLE
Fixes compile issue with AutoCapitalization on Xcode 14.2 and below

### DIFF
--- a/Sources/SwiftUIBackports/iOS/AutoCapitalization/AutoCapitalization.swift
+++ b/Sources/SwiftUIBackports/iOS/AutoCapitalization/AutoCapitalization.swift
@@ -26,21 +26,7 @@ public extension Backport where Wrapped: View {
     func textInputAutocapitalization(_ autocapitalization: Backport<Any>.TextInputAutocapitalization?) -> some View {
         Group {
             if #available(iOS 16, *) {
-                var type: SwiftUI.TextInputAutocapitalization {
-                    switch autocapitalization {
-                    case .none:
-                        return .sentences
-                    case .some(let wrapped):
-                        switch wrapped {
-                        case .never: return .never
-                        case .words: return .words
-                        case .sentences: return .sentences
-                        case .characters: return .characters
-                        default: return .sentences
-                        }
-                    }
-                }
-                wrapped.textInputAutocapitalization(type)
+                wrapped.textInputAutocapitalization(textInputAutocapitalizationType(autocapitalization))
             } else {
                 wrapped.modifier(
                     AutoCapitalizationModifier(
@@ -50,6 +36,22 @@ public extension Backport where Wrapped: View {
             }
         }
         .environment(\.textInputAutocapitalization, autocapitalization)
+    }
+    
+    @available(iOS 16.0, *)
+    private func textInputAutocapitalizationType(_ autocapitalization: Backport<Any>.TextInputAutocapitalization?) -> SwiftUI.TextInputAutocapitalization {
+        switch autocapitalization {
+        case .none:
+            return .sentences
+        case .some(let wrapped):
+            switch wrapped {
+            case .never: return .never
+            case .words: return .words
+            case .sentences: return .sentences
+            case .characters: return .characters
+            default: return .sentences
+            }
+        }
     }
 }
 


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/shaps80/.github/blob/master/CONTRIBUTING.md)?*

Issue #42 

## Describe your changes

This change moves the conversion of `Backport<Any>.TextInputAutocapitalization` to `SwiftUI.TextInputAutocapitalization` out of the result builder (`Group`) and into a `private func`. This works around the compiler error encountered when using Xcode 14.2 or earlier.
