### PR TITLE
Improve presentation detents backport

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,11 @@ let package = Package(
     targets: [
         .target(
             name: "SwiftUIBackports",
-            dependencies: ["SwiftBackports"]
+            dependencies: ["SwiftBackports", "SwiftUIBackportsC"]
+        ),
+        .target(
+            name: "SwiftUIBackportsC",
+            publicHeadersPath: "Internal"
         )
     ],
     swiftLanguageVersions: [.v5]

--- a/Sources/SwiftUIBackports/Shared/Toolbar/ToolbarBackground.swift
+++ b/Sources/SwiftUIBackports/Shared/Toolbar/ToolbarBackground.swift
@@ -34,29 +34,29 @@ public extension Backport<Any> {
     }
 }
 
-//@available(iOS, deprecated: 16)
-//@available(macOS, deprecated: 13)
-//@available(tvOS, unavailable)
-//@available(watchOS, unavailable)
-//public extension Backport where Wrapped: View {
-//    func toolbarBackground(_ visibility: Backport<Any>.Visibility, for bars: Backport<Any>.ToolbarPlacement...) -> some View {
-//        content
-//            .modifier(ToolbarBackgroundModifier())
-//            .environment(\.toolbarVisibility, .init(
-//                navigationBar: bars.contains(.navigationBar) ? visibility : nil,
-//                bottomBar: bars.contains(.bottomBar) ? visibility : nil,
-//                tabBar: bars.contains(.tabBar) ? visibility : nil)
-//            )
-//    }
-//
-//    func toolbarBackground<S>(_ style: S, for bars: Backport<Any>.ToolbarPlacement...) -> some View where S: ShapeStyle & View {
-//        content
-//            .modifier(ToolbarBackgroundModifier())
-//            .environment(\.toolbarViews, .init(
-//                navigationBar: bars.contains(.navigationBar) ? .init(style) : nil,
-//                bottomBar: bars.contains(.bottomBar) ? .init(style) : nil,
-//                tabBar: bars.contains(.tabBar) ? .init(style) : nil)
-//            )
-//    }
-//}
+@available(iOS, deprecated: 16)
+@available(macOS, deprecated: 13)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+public extension Backport where Wrapped: View {
+    func toolbarBackground(_ visibility: Backport<Any>.Visibility, for bars: Backport<Any>.ToolbarPlacement...) -> some View {
+        wrapped
+            .modifier(ToolbarBackgroundModifier())
+            .environment(\.toolbarVisibility, .init(
+                navigationBar: bars.contains(.navigationBar) ? visibility : nil,
+                bottomBar: bars.contains(.bottomBar) ? visibility : nil,
+                tabBar: bars.contains(.tabBar) ? visibility : nil)
+            )
+    }
+
+    func toolbarBackground<S>(_ style: S, for bars: Backport<Any>.ToolbarPlacement...) -> some View where S: ShapeStyle & View {
+        wrapped
+            .modifier(ToolbarBackgroundModifier())
+            .environment(\.toolbarViews, .init(
+                navigationBar: bars.contains(.navigationBar) ? .init(style) : nil,
+                bottomBar: bars.contains(.bottomBar) ? .init(style) : nil,
+                tabBar: bars.contains(.tabBar) ? .init(style) : nil)
+            )
+    }
+}
 #endif

--- a/Sources/SwiftUIBackports/iOS/Presentation/BackgroundInteraction.swift
+++ b/Sources/SwiftUIBackports/iOS/Presentation/BackgroundInteraction.swift
@@ -152,7 +152,7 @@ private extension Backport.Representable {
                         controller.largestUndimmedDetentIdentifier = .init(detent.id.rawValue)
 
                         let selectedId = controller.selectedDetentIdentifier ?? .large
-                        let selected = Backport<Any>.PresentationDetent(id: .init(rawValue: selectedId.rawValue))
+                        let selected = Backport<Any>.PresentationDetent(id: .init(rawValue: selectedId.rawValue))!
                         controller.presentingViewController.view?.tintAdjustmentMode = selected > detent ? .dimmed : .normal
                     }
                 }

--- a/Sources/SwiftUIBackports/iOS/Presentation/InteractiveDetent.swift
+++ b/Sources/SwiftUIBackports/iOS/Presentation/InteractiveDetent.swift
@@ -1,57 +1,57 @@
 import SwiftUI
 import SwiftBackports
 
-@available(iOS, deprecated: 16)
-@available(tvOS, deprecated: 16)
-@available(macOS, deprecated: 13)
-@available(watchOS, deprecated: 9)
-public extension Backport where Wrapped: View {
-
-    /// Removes dimming from detents higher (and including) the provided identifier
-    ///
-    /// This has two affects on dentents higher than the identifier provided:
-    /// 1. Touches will passthrough to the views below the sheet.
-    /// 2. Touches will no longer dismiss the sheet automatically when tapping outside of the sheet.
-    ///
-    /// ```
-    ///     struct ContentView: View {
-    ///         @State private var showSettings = false
-    ///
-    ///         var body: some View {
-    ///             Button("View Settings") {
-    ///                 showSettings = true
-    ///             }
-    ///             .sheet(isPresented: $showSettings) {
-    ///                 SettingsView()
-    ///                     .presentationDetents:([.medium, .large])
-    ///                     .presentationUndimmed(from: .medium)
-    ///             }
-    ///         }
-    ///     }
-    /// ```
-    ///
-    /// - Parameter identifier: The identifier of the largest detent that is not dimmed.
-    @ViewBuilder
-    @available(iOS, deprecated: 13, message: "Please use backport.presentationDetents(_:selection:largestUndimmedDetent:)")
-    func presentationUndimmed(from identifier: Backport<Any>.PresentationDetent.Identifier?) -> some View {
-        #if os(iOS)
-        if #available(iOS 15, *) {
-            wrapped.background(Backport<Any>.Representable(identifier: identifier))
-        } else {
-            wrapped
-        }
-        #else
-        wrapped
-        #endif
-    }
-
-}
+//@available(iOS, deprecated: 16)
+//@available(tvOS, deprecated: 16)
+//@available(macOS, deprecated: 13)
+//@available(watchOS, deprecated: 9)
+//public extension Backport where Wrapped: View {
+//
+//    /// Removes dimming from detents higher (and including) the provided identifier
+//    ///
+//    /// This has two affects on dentents higher than the identifier provided:
+//    /// 1. Touches will passthrough to the views below the sheet.
+//    /// 2. Touches will no longer dismiss the sheet automatically when tapping outside of the sheet.
+//    ///
+//    /// ```
+//    ///     struct ContentView: View {
+//    ///         @State private var showSettings = false
+//    ///
+//    ///         var body: some View {
+//    ///             Button("View Settings") {
+//    ///                 showSettings = true
+//    ///             }
+//    ///             .sheet(isPresented: $showSettings) {
+//    ///                 SettingsView()
+//    ///                     .presentationDetents:([.medium, .large])
+//    ///                     .presentationUndimmed(from: .medium)
+//    ///             }
+//    ///         }
+//    ///     }
+//    /// ```
+//    ///
+//    /// - Parameter identifier: The identifier of the largest detent that is not dimmed.
+//    @ViewBuilder
+//    @available(iOS, deprecated: 13, message: "Please use backport.presentationDetents(_:selection:largestUndimmedDetent:)")
+//    func presentationUndimmed(from identifier: Backport<Any>.PresentationDetent.Identifier?) -> some View {
+//        #if os(iOS)
+//        if #available(iOS 15, *) {
+//            wrapped.background(Backport<Any>.Representable(identifier: identifier))
+//        } else {
+//            wrapped
+//        }
+//        #else
+//        wrapped
+//        #endif
+//    }
+//
+//}
 
 #if os(iOS)
 @available(iOS 15, *)
 private extension Backport where Wrapped == Any {
     struct Representable: UIViewControllerRepresentable {
-        let identifier: Backport<Any>.PresentationDetent.Identifier?
+        let identifier: UISheetPresentationController.Detent.Identifier?
 
         func makeUIViewController(context: Context) -> Backport.Representable.Controller {
             Controller(identifier: identifier)
@@ -67,9 +67,9 @@ private extension Backport where Wrapped == Any {
 private extension Backport.Representable {
     final class Controller: UIViewController {
 
-        var identifier: Backport<Any>.PresentationDetent.Identifier?
+        var identifier: UISheetPresentationController.Detent.Identifier?
 
-        init(identifier: Backport<Any>.PresentationDetent.Identifier?) {
+        init(identifier: UISheetPresentationController.Detent.Identifier?) {
             self.identifier = identifier
             super.init(nibName: nil, bundle: nil)
         }
@@ -83,7 +83,7 @@ private extension Backport.Representable {
             update(identifier: identifier)
         }
 
-        func update(identifier: Backport<Any>.PresentationDetent.Identifier?) {
+        func update(identifier: UISheetPresentationController.Detent.Identifier?) {
             self.identifier = identifier
 
             if let controller = parent?.sheetPresentationController {

--- a/Sources/SwiftUIBackportsC/Dummy.m
+++ b/Sources/SwiftUIBackportsC/Dummy.m
@@ -1,0 +1,8 @@
+//
+//  Dummy.m
+//  
+//
+//  Created by Alexis Schultz on 09/06/2023.
+//
+
+#import <Foundation/Foundation.h>

--- a/Sources/SwiftUIBackportsC/Internal/Internal.h
+++ b/Sources/SwiftUIBackportsC/Internal/Internal.h
@@ -1,0 +1,16 @@
+//
+//  Header.h
+//  
+//
+//  Created by Alexis Schultz on 09/06/2023.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UISheetPresentationControllerDetent (Private)
++ (UISheetPresentationControllerDetent *)_detentWithIdentifier:(NSString *)identifier constant:(CGFloat)constant;
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
https://github.com/shaps80/SwiftUIBackports/issues/52

## Describe your changes

Improve PresentationDetents on iOS 15 by adding support for .height(value) as a detent.
Note the backport is using private apis on iOS 15.0 to 16.0 and regular api above iOS 16.0.

The comparable implementation is not perfect and I think should be removed.

This is unfinished as I just leant about the `.presentationDetents(undimmed:largestUndimmed:)` but I wanted your feedback about the ObjC/Private api use
