### PR TITLE
Fix the used actor in the task view modifier that should inherit from context instead of main actor

### DIFF
--- a/Sources/SwiftUIBackports/Shared/Task/Task.swift
+++ b/Sources/SwiftUIBackports/Shared/Task/Task.swift
@@ -50,7 +50,7 @@ public extension Backport where Wrapped: View {
     /// - Returns: A view that runs the specified action asynchronously when
     ///   the view appears.
     @ViewBuilder
-    func task(priority: TaskPriority = .userInitiated, _ action: @MainActor @escaping @Sendable () async -> Void) -> some View {
+    func task(priority: TaskPriority = .userInitiated, @_inheritActorContext _ action: @escaping @Sendable () async -> Void) -> some View {
         wrapped.modifier(
             TaskModifier(
                 id: 0,
@@ -120,7 +120,7 @@ public extension Backport where Wrapped: View {
     /// - Returns: A view that runs the specified action asynchronously when
     ///   the view appears, or restarts the task with the `id` value changes.
     @ViewBuilder
-    func task<T: Equatable>(id: T, priority: TaskPriority = .userInitiated, _ action: @MainActor @escaping @Sendable () async -> Void) -> some View {
+    func task<T: Equatable>(id: T, priority: TaskPriority = .userInitiated, @_inheritActorContext _ action: @escaping @Sendable () async -> Void) -> some View {
         wrapped.modifier(
             TaskModifier(
                 id: id,
@@ -136,11 +136,11 @@ private struct TaskModifier<ID: Equatable>: ViewModifier {
 
     var id: ID
     var priority: TaskPriority
-    var action: () async -> Void
+    var action: @Sendable () async -> Void
 
     @State private var task: Task<Void, Never>?
 
-    init(id: ID, priority: TaskPriority, action: @MainActor @escaping () async -> Void) {
+    init(id: ID, priority: TaskPriority, action: @Sendable @escaping () async -> Void) {
         self.id = id
         self.priority = priority
         self.action = action
@@ -150,15 +150,11 @@ private struct TaskModifier<ID: Equatable>: ViewModifier {
         content
             .backport.onChange(of: id) { _ in
                 task?.cancel()
-                task = Task(priority: priority) {
-                    await action()
-                }
+                task = Task(priority: priority, operation: action)
             }
             .onAppear {
                 task?.cancel()
-                task = Task(priority: priority) {
-                    await action()
-                }
+                task = Task(priority: priority, operation: action)
             }
             .onDisappear {
                 task?.cancel()


### PR DESCRIPTION
## Describe your changes

In the current implementation made by Apple, we can see in the signature that the action isn't flagged as `@MainActor`
<img width="1194" alt="image" src="https://github.com/shaps80/SwiftUIBackports/assets/19294297/83be7524-0068-4ee4-bce8-efd1ee1a93a2">
This is because the action isn't forced to run on the main actor, instead, it does inherit from the context actor.
This [article](https://oleb.net/2022/swiftui-task-mainactor/) explains it better than I would do.


I did remove the conformance to `@MainActor` to add `@_inheritActorContext` on the action parameter so we are ISO with the implementation in iOS>14