### PR TITLE
Fix endless recursion by avoiding to link _delegates more than once

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/shaps80/SwiftBackports",
       "state" : {
-        "revision" : "fafbeabf78b7e364abbbb7565cdfeee42af16211",
-        "version" : "1.0.2"
+        "revision" : "ddca6a237c1ba2291d5a3cc47ec8480ce6e9f805",
+        "version" : "1.0.3"
       }
     }
   ],

--- a/Sources/SwiftUIBackports/iOS/FocusState/ViewFocused.swift
+++ b/Sources/SwiftUIBackports/iOS/FocusState/ViewFocused.swift
@@ -60,7 +60,7 @@ private final class Coordinator: NSObject, ObservableObject, UITextFieldDelegate
     func observe(field: UITextField) {
         self.field = field
 
-        if field.delegate !== self {
+        if field.delegate !== self && _delegate == nil {
             _delegate = field.delegate
             field.delegate = self
         }

--- a/Sources/SwiftUIBackports/iOS/Presentation/Detents.swift
+++ b/Sources/SwiftUIBackports/iOS/Presentation/Detents.swift
@@ -169,7 +169,7 @@ private extension Backport.Representable {
         override func willMove(toParent parent: UIViewController?) {
             super.willMove(toParent: parent)
             if let controller = parent?.sheetPresentationController {
-                if controller.delegate !== self && _delegate != nil {
+                if controller.delegate !== self && _delegate == nil {
                     _delegate = controller.delegate
                     controller.delegate = self
                 }

--- a/Sources/SwiftUIBackports/iOS/Presentation/Detents.swift
+++ b/Sources/SwiftUIBackports/iOS/Presentation/Detents.swift
@@ -169,7 +169,7 @@ private extension Backport.Representable {
         override func willMove(toParent parent: UIViewController?) {
             super.willMove(toParent: parent)
             if let controller = parent?.sheetPresentationController {
-                if controller.delegate !== self {
+                if controller.delegate !== self && _delegate != nil {
                     _delegate = controller.delegate
                     controller.delegate = self
                 }

--- a/Sources/SwiftUIBackports/iOS/Presentation/InteractiveDismiss.swift
+++ b/Sources/SwiftUIBackports/iOS/Presentation/InteractiveDismiss.swift
@@ -194,7 +194,7 @@ private extension Backport.Representable {
         override func willMove(toParent parent: UIViewController?) {
             super.willMove(toParent: parent)
             if let controller = parent?.presentationController {
-                if controller.delegate !== self  && _delegate != nil {
+                if controller.delegate !== self  && _delegate == nil {
                     _delegate = controller.delegate
                     controller.delegate = self
                 }

--- a/Sources/SwiftUIBackports/iOS/Presentation/InteractiveDismiss.swift
+++ b/Sources/SwiftUIBackports/iOS/Presentation/InteractiveDismiss.swift
@@ -194,7 +194,7 @@ private extension Backport.Representable {
         override func willMove(toParent parent: UIViewController?) {
             super.willMove(toParent: parent)
             if let controller = parent?.presentationController {
-                if controller.delegate !== self {
+                if controller.delegate !== self  && _delegate != nil {
                     _delegate = controller.delegate
                     controller.delegate = self
                 }


### PR DESCRIPTION
In the overrides to willMove(toParent parent: UIViewController?) in Detents.swift and also InteractiveDismiss.swift the controller injects itself to the chain of delegates. Apparently the function is called more than once for the same controller if the device orientation changes. When a sheet is used with both .backport.presentationDetents([.medium]) and .backport.interactiveDismissDisabled(true) then multiple willMove calls will result in a cycle in the linked delegate which will then result in an endless recursion.

To avoid the recursion and the crash we just check if _delegate has not been set before.

Resolves: #62
