### PR TITLE
Expose LabeledContentStyleConfiguration.labelHidden getter

### DIFF
--- a/Sources/SwiftUIBackports/Shared/LabeledContent/LabeledContentStyleConfiguration.swift
+++ b/Sources/SwiftUIBackports/Shared/LabeledContent/LabeledContentStyleConfiguration.swift
@@ -20,7 +20,7 @@ extension Backport where Wrapped == Any {
             }
         }
 
-        var labelHidden: Bool = false
+        public internal(set) var labelHidden: Bool = false
 
         private let _label: AnyView
 


### PR DESCRIPTION
Exposes the getter for the `LabeledContentStyleConfiguration.labelHidden` property. This allows implementations of the protocol to utilize it, just like `AutomaticLabeledContentStyle`.