### PR TITLE
Add privacy manifest for UserDefaults

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,8 @@ let package = Package(
     targets: [
         .target(
             name: "SwiftUIBackports",
-            dependencies: ["SwiftBackports"]
+            dependencies: ["SwiftBackports"],
+            resources: [.process("Resources/PrivacyInfo.xcprivacy")]
         )
     ],
     swiftLanguageVersions: [.v5]

--- a/Sources/SwiftUIBackports/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/SwiftUIBackports/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Description
Because the library uses `UserDefaults`, it has to contain PrivacyInfo manifest, check [Apple doc](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401)

### Why is this needed?

> Starting March 13: If you upload a new or updated app to App Store Connect that uses an API requiring approved reasons, we’ll send you an email letting you know if you’re missing reasons in your app’s privacy manifest. This is in addition to the existing notification in App Store Connect.
> 
> Starting May 1: You’ll need to include approved reasons for the listed APIs used by your app’s code to upload a new or updated app to App Store Connect. If you’re not using an API for an allowed reason, please find an alternative. And if you add a new third-party SDK that’s on the list of commonly used third-party SDKs, these API, privacy manifest, and signature requirements will apply to that SDK. Make sure to use a version of the SDK that includes its privacy manifest and note that signatures are also required when the SDK is added as a binary dependency.

https://developer.apple.com/news/?id=3d8a9yyh


