### PR TITLE
Feat/presentation detents height fraction (iOS 16+ namespace add)

### DIFF
--- a/Sources/SwiftUIBackports/iOS/Presentation/Detents.swift
+++ b/Sources/SwiftUIBackports/iOS/Presentation/Detents.swift
@@ -304,7 +304,7 @@ private extension Backport.Representable {
                 if #available(iOS 16, *) {
                     return .custom(identifier: .init(detent.id.rawValue)) { _ in height }
                 } else {
-                    Self.warnUnsupportedDetentOnce("PresentationDetent.height(\(height)) requires iOS 16+; falling back to .medium")
+                    warnUnsupportedDetentOnce("PresentationDetent.height(\(height)) requires iOS 16+; falling back to .medium")
                     return .medium()
                 }
             }
@@ -314,7 +314,7 @@ private extension Backport.Representable {
                         fraction * context.maximumDetentValue
                     }
                 } else {
-                    Self.warnUnsupportedDetentOnce("PresentationDetent.fraction(\(fraction)) requires iOS 16+; falling back to .medium")
+                    warnUnsupportedDetentOnce("PresentationDetent.fraction(\(fraction)) requires iOS 16+; falling back to .medium")
                     return .medium()
                 }
             }

--- a/Sources/SwiftUIBackports/iOS/Presentation/Detents.swift
+++ b/Sources/SwiftUIBackports/iOS/Presentation/Detents.swift
@@ -101,6 +101,14 @@ public extension Backport<Any> {
             public static var large: Identifier {
                 .init(rawValue: "com.apple.UIKit.large")
             }
+
+            /// Raw-value prefix used to encode the value of a
+            /// ``Backport/PresentationDetent/height(_:)`` detent.
+            fileprivate static let heightPrefix = "com.apple.UIKit.height."
+
+            /// Raw-value prefix used to encode the value of a
+            /// ``Backport/PresentationDetent/fraction(_:)`` detent.
+            fileprivate static let fractionPrefix = "com.apple.UIKit.fraction."
         }
 
         public let id: Identifier
@@ -116,17 +124,69 @@ public extension Backport<Any> {
             .init(id: .large)
         }
 
+        /// A custom detent with the specified height.
+        ///
+        /// On iOS 16+ this is resolved through
+        /// ``UISheetPresentationController/Detent/custom(identifier:resolver:)``
+        /// with a constant resolver. On iOS 15 there is no native equivalent —
+        /// the sheet falls back to ``medium`` and emits a runtime warning the
+        /// first time the fallback is hit per process.
+        ///
+        /// - Parameter height: The height of the detent in points.
+        public static func height(_ height: CGFloat) -> PresentationDetent {
+            .init(id: .init(rawValue: "\(Identifier.heightPrefix)\(height)"))
+        }
+
+        /// A custom detent with a height that's a fraction of the available
+        /// detent height.
+        ///
+        /// On iOS 16+ this is resolved through
+        /// ``UISheetPresentationController/Detent/custom(identifier:resolver:)``
+        /// using `fraction * context.maximumDetentValue`. On iOS 15 there is no
+        /// native equivalent — the sheet falls back to ``medium`` and emits a
+        /// runtime warning the first time the fallback is hit per process.
+        ///
+        /// - Parameter fraction: The fraction of the available detent height.
+        public static func fraction(_ fraction: CGFloat) -> PresentationDetent {
+            .init(id: .init(rawValue: "\(Identifier.fractionPrefix)\(fraction)"))
+        }
+
         fileprivate static var none: PresentationDetent {
             return .init(id: .init(rawValue: ""))
         }
 
+        /// Decoded numeric value when the identifier was created via
+        /// ``height(_:)``, otherwise `nil`.
+        internal var heightValue: CGFloat? {
+            guard id.rawValue.hasPrefix(Identifier.heightPrefix) else { return nil }
+            let suffix = id.rawValue.dropFirst(Identifier.heightPrefix.count)
+            return Double(suffix).map { CGFloat($0) }
+        }
+
+        /// Decoded fraction when the identifier was created via
+        /// ``fraction(_:)``, otherwise `nil`.
+        internal var fractionValue: CGFloat? {
+            guard id.rawValue.hasPrefix(Identifier.fractionPrefix) else { return nil }
+            let suffix = id.rawValue.dropFirst(Identifier.fractionPrefix.count)
+            return Double(suffix).map { CGFloat($0) }
+        }
+
+        /// Approximate ordering key used to sort detents into the ascending
+        /// order expected by `UISheetPresentationController.detents`.
+        ///
+        /// Heights and fractions sort by numeric value; `.medium` and `.large`
+        /// are placed at conservative defaults so a mixed array sorts in a
+        /// reasonable order without resolving the runtime screen size.
+        private var sortKey: Double {
+            if let value = heightValue { return Double(value) }
+            if let value = fractionValue { return Double(value) * 600 }
+            if id == .medium { return 400 }
+            if id == .large { return 800 }
+            return 0
+        }
+
         public static func < (lhs: PresentationDetent, rhs: PresentationDetent) -> Bool {
-            switch (lhs, rhs) {
-            case (.large, .medium):
-                return false
-            default:
-                return true
-            }
+            lhs.sortKey < rhs.sortKey
         }
     }
 }
@@ -189,13 +249,8 @@ private extension Backport.Representable {
 
             if let controller = parent?.sheetPresentationController {
                 controller.animateChanges {
-                    controller.detents = detents.sorted().map {
-                        switch $0 {
-                        case .medium:
-                            return .medium()
-                        default:
-                            return .large()
-                        }
+                    controller.detents = detents.sorted().map { detent in
+                        Self.systemDetent(for: detent)
                     }
 
                     if let selection = selection {
@@ -234,6 +289,49 @@ private extension Backport.Representable {
         override func forwardingTarget(for aSelector: Selector!) -> Any? {
             if super.responds(to: aSelector) { return self }
             return _delegate
+        }
+
+        /// Resolves a ``Backport/PresentationDetent`` to the system
+        /// `UISheetPresentationController.Detent` that should be applied.
+        ///
+        /// On iOS 16+, `.height` and `.fraction` are bridged via
+        /// `Detent.custom(identifier:resolver:)`, preserving the identifier so
+        /// that ``selection`` round-trips correctly. On iOS 15 the system has
+        /// no custom-detent API, so both fall back to ``.medium()`` and emit a
+        /// one-shot runtime warning to aid debugging.
+        static func systemDetent(for detent: Backport<Any>.PresentationDetent) -> UISheetPresentationController.Detent {
+            if let height = detent.heightValue {
+                if #available(iOS 16, *) {
+                    return .custom(identifier: .init(detent.id.rawValue)) { _ in height }
+                } else {
+                    Self.warnUnsupportedDetentOnce("PresentationDetent.height(\(height)) requires iOS 16+; falling back to .medium")
+                    return .medium()
+                }
+            }
+            if let fraction = detent.fractionValue {
+                if #available(iOS 16, *) {
+                    return .custom(identifier: .init(detent.id.rawValue)) { context in
+                        fraction * context.maximumDetentValue
+                    }
+                } else {
+                    Self.warnUnsupportedDetentOnce("PresentationDetent.fraction(\(fraction)) requires iOS 16+; falling back to .medium")
+                    return .medium()
+                }
+            }
+            switch detent {
+            case .medium:
+                return .medium()
+            default:
+                return .large()
+            }
+        }
+
+        private static let unsupportedDetentWarnings: NSMutableSet = .init()
+
+        private static func warnUnsupportedDetentOnce(_ message: String) {
+            guard unsupportedDetentWarnings.contains(message) == false else { return }
+            unsupportedDetentWarnings.add(message)
+            print("[SwiftUIBackports] \(message)")
         }
     }
 }

--- a/Sources/SwiftUIBackports/iOS/Presentation/Detents.swift
+++ b/Sources/SwiftUIBackports/iOS/Presentation/Detents.swift
@@ -126,13 +126,20 @@ public extension Backport<Any> {
 
         /// A custom detent with the specified height.
         ///
-        /// On iOS 16+ this is resolved through
+        /// Resolved through
         /// ``UISheetPresentationController/Detent/custom(identifier:resolver:)``
-        /// with a constant resolver. On iOS 15 there is no native equivalent —
-        /// the sheet falls back to ``medium`` and emits a runtime warning the
-        /// first time the fallback is hit per process.
+        /// with a constant resolver.
+        ///
+        /// Marked `@available(iOS 16, *)` because the underlying
+        /// `Detent.custom(...)` API was only added in iOS 16; iOS 15's
+        /// `UISheetPresentationController` has no equivalent. Exposing this
+        /// factory through the `Backport` namespace gives callers that adopt
+        /// `.backport.*` API shapes consistent factory names once their
+        /// deployment target reaches iOS 16, without forcing them to switch
+        /// to a different module just for these two detents.
         ///
         /// - Parameter height: The height of the detent in points.
+        @available(iOS 16, *)
         public static func height(_ height: CGFloat) -> PresentationDetent {
             .init(id: .init(rawValue: "\(Identifier.heightPrefix)\(height)"))
         }
@@ -140,13 +147,17 @@ public extension Backport<Any> {
         /// A custom detent with a height that's a fraction of the available
         /// detent height.
         ///
-        /// On iOS 16+ this is resolved through
+        /// Resolved through
         /// ``UISheetPresentationController/Detent/custom(identifier:resolver:)``
-        /// using `fraction * context.maximumDetentValue`. On iOS 15 there is no
-        /// native equivalent — the sheet falls back to ``medium`` and emits a
-        /// runtime warning the first time the fallback is hit per process.
+        /// using `fraction * context.maximumDetentValue`.
+        ///
+        /// Marked `@available(iOS 16, *)` because the underlying
+        /// `Detent.custom(...)` API was only added in iOS 16; iOS 15's
+        /// `UISheetPresentationController` has no equivalent. See
+        /// ``height(_:)`` for the rationale around the `Backport` namespace.
         ///
         /// - Parameter fraction: The fraction of the available detent height.
+        @available(iOS 16, *)
         public static func fraction(_ fraction: CGFloat) -> PresentationDetent {
             .init(id: .init(rawValue: "\(Identifier.fractionPrefix)\(fraction)"))
         }
@@ -177,6 +188,12 @@ public extension Backport<Any> {
         /// Heights and fractions sort by numeric value; `.medium` and `.large`
         /// are placed at conservative defaults so a mixed array sorts in a
         /// reasonable order without resolving the runtime screen size.
+        ///
+        /// Note that even ignoring the custom-detent factories, the previous
+        /// implementation of `<` violated `Comparable`'s irreflexivity
+        /// requirement (`lhs < lhs` returned `true` for everything except
+        /// `.large < .medium`); replacing it with a numeric key restores the
+        /// expected `x < x == false` semantics.
         private var sortKey: Double {
             if let value = heightValue { return Double(value) }
             if let value = fractionValue { return Double(value) * 600 }
@@ -296,26 +313,19 @@ private extension Backport.Representable {
         ///
         /// On iOS 16+, `.height` and `.fraction` are bridged via
         /// `Detent.custom(identifier:resolver:)`, preserving the identifier so
-        /// that ``selection`` round-trips correctly. On iOS 15 the system has
-        /// no custom-detent API, so both fall back to ``.medium()`` and emit a
-        /// one-shot runtime warning to aid debugging.
+        /// that ``selection`` round-trips correctly. On iOS 15 the only
+        /// reachable cases are ``Backport/PresentationDetent/medium`` and
+        /// ``Backport/PresentationDetent/large``; the custom factories are
+        /// `@available(iOS 16, *)` so they cannot appear in `detents` there.
         static func systemDetent(for detent: Backport<Any>.PresentationDetent) -> UISheetPresentationController.Detent {
-            if let height = detent.heightValue {
-                if #available(iOS 16, *) {
+            if #available(iOS 16, *) {
+                if let height = detent.heightValue {
                     return .custom(identifier: .init(detent.id.rawValue)) { _ in height }
-                } else {
-                    warnUnsupportedDetentOnce("PresentationDetent.height(\(height)) requires iOS 16+; falling back to .medium")
-                    return .medium()
                 }
-            }
-            if let fraction = detent.fractionValue {
-                if #available(iOS 16, *) {
+                if let fraction = detent.fractionValue {
                     return .custom(identifier: .init(detent.id.rawValue)) { context in
                         fraction * context.maximumDetentValue
                     }
-                } else {
-                    warnUnsupportedDetentOnce("PresentationDetent.fraction(\(fraction)) requires iOS 16+; falling back to .medium")
-                    return .medium()
                 }
             }
             switch detent {
@@ -324,14 +334,6 @@ private extension Backport.Representable {
             default:
                 return .large()
             }
-        }
-
-        private static let unsupportedDetentWarnings: NSMutableSet = .init()
-
-        private static func warnUnsupportedDetentOnce(_ message: String) {
-            guard unsupportedDetentWarnings.contains(message) == false else { return }
-            unsupportedDetentWarnings.add(message)
-            print("[SwiftUIBackports] \(message)")
         }
     }
 }


### PR DESCRIPTION
## Summary
 
Adds the iOS 16+ parametric detent factories `.height(_:)` and `.fraction(_:)` to `Backport<Any>.PresentationDetent`, marked `@available(iOS 16, *)` so that iOS 15 callers cannot construct them. **Restructured in response to review feedback** — the original revision silently degraded `.height/.fraction` to `.medium()` on iOS 15, which (per @shaps80's review) isn't really a backport pattern. This revision drops that fallback entirely.
 
### Why include this in `Backport` at all
 
Strictly speaking, iOS 16+ callers can use Apple's native `PresentationDetent.height(_:)` / `.fraction(_:)`. The value of having them in `Backport<Any>.PresentationDetent` is **namespace completeness for codebases that already adopt `.backport.presentationDetents(...)` as their cross-version entry point**. Without these factories, such a codebase has to write:
 
```swift
if #available(iOS 16, *) {
    content.presentationDetents([.height(200), .medium])             // native
} else {
    content.backport.presentationDetents([.medium])                  // backport
}
```
 
With these factories the iOS 16 branch can stay on `.backport.*`:
 
```swift
if #available(iOS 16, *) {
    content.backport.presentationDetents([.height(200), .medium])    // backport
} else {
    content.backport.presentationDetents([.medium])                  // backport
}
```
 
Same factory names, same module, fewer call-site shapes to maintain. If you don't buy that as a meaningful win this PR is closeable on the merits — I think it's worth the small surface-area add, but it's a soft argument.
 
### What this PR contains
 
1. **`.height(_:)` and `.fraction(_:)` factories** on `Backport<Any>.PresentationDetent`, both `@available(iOS 16, *)`. They construct a `PresentationDetent` whose `Identifier.rawValue` encodes the height/fraction via a stable prefix (`com.apple.UIKit.height.` / `com.apple.UIKit.fraction.`), so the public `Hashable / Equatable` conformance keeps working without adding stored properties or changing the struct's storage shape.
 
2. **Bridging in `Backport.Representable.Controller.systemDetent(for:)`** — wraps the `.custom(identifier:resolver:)` calls in a single `if #available(iOS 16, *)` block. On iOS 15 the only reachable cases are `.medium` and `.large` (the custom factories can't be constructed there at compile time), so the iOS 15 path is the trivial medium/large switch.
 
3. **No iOS 15 fallback machinery.** No runtime warning helper, no "fall back to `.medium`", no silent degradation. This is the change relative to the original revision of the PR.
 
4. **`Comparable` rewrite** around a numeric `sortKey` so a mixed set of detents (e.g. `[.height(120), .medium, .large]`) sorts into ascending size order when passed to `UISheetPresentationController.detents` on iOS 16+. Independent of the new factories this also fixes a latent bug: the previous `<` implementation returned `true` for every comparison except `.large < .medium`, violating `Comparable`'s irreflexivity requirement (`lhs < lhs` was `true` for everything except `.large`).
 
If you'd prefer the `Comparable` fix as a standalone PR (it's a defensible bug fix even without `.height`/`.fraction`), happy to split it out — let me know.
 
### Known limitation of `sortKey`
 
`sortKey` approximates `.medium`/`.large` at 400/800 points without resolving the runtime screen size. On tall devices `.medium` resolves to ~500pt, so e.g. `.height(450)` (sortKey 450) sorts above `.medium` (sortKey 400) even though `.medium` is taller at runtime. Fixing this properly requires comparing resolved heights, which `Comparable` cannot do without a context.