### PR TITLE
FEAT: Backport presentationBackground modifier for iOS 15-16.3

### DIFF
--- a/Sources/SwiftUIBackports/Shared/PresentationBackground/PresentationBackground.swift
+++ b/Sources/SwiftUIBackports/Shared/PresentationBackground/PresentationBackground.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+import SwiftBackports
+
+@available(iOS, deprecated: 16.4)
+@available(tvOS, deprecated: 16.4)
+@available(macOS, deprecated: 13.3)
+@available(watchOS, deprecated: 9.4)
+@MainActor
+public extension Backport where Wrapped: View {
+
+    /// Sets the presentation background of the enclosing sheet using a shape style.
+    ///
+    /// The following example uses the `thick` material as the sheet background:
+    ///
+    ///     struct ContentView: View {
+    ///         @State private var showSettings = false
+    ///
+    ///         var body: some View {
+    ///             Button("View Settings") {
+    ///                 showSettings = true
+    ///             }
+    ///             .sheet(isPresented: $showSettings) {
+    ///                 SettingsView()
+    ///                     .backport.presentationBackground(.thickMaterial)
+    ///             }
+    ///         }
+    ///     }
+    ///
+    /// The `presentationBackground(_:)` modifier differs from the `background(_:)`
+    /// modifier in several key ways. A presentation background:
+    ///
+    /// - Automatically fills the entire presentation.
+    /// - Allows views behind the presentation to show through translucent styles
+    ///   on supported platforms.
+    ///
+    /// On iOS 15 the background is rendered behind the sheet content via SwiftUI's
+    /// regular `background` modifier, and the underlying `UIHostingController` view
+    /// background is cleared so the supplied style is what the user sees. This
+    /// approximates the native behavior closely for the common case where the
+    /// modifier is applied to the root of a presented modal.
+    ///
+    /// - Parameter style: The shape style to use as the presentation background.
+    @ViewBuilder
+    @available(iOS, introduced: 15, deprecated: 16.4, message: "Presentation background is supported natively on iOS 16.4+")
+    func presentationBackground<S: ShapeStyle>(_ style: S) -> some View {
+        #if os(iOS)
+        if #available(iOS 16.4, *) {
+            wrapped.presentationBackground(style)
+        } else {
+            wrapped
+                .background(style, ignoresSafeAreaEdges: .all)
+                .background(BackgroundClearer())
+        }
+        #else
+        wrapped
+        #endif
+    }
+
+    /// Sets the presentation background of the enclosing sheet to a custom view.
+    ///
+    /// The following example uses a yellow view as the sheet background:
+    ///
+    ///     struct ContentView: View {
+    ///         @State private var showSettings = false
+    ///
+    ///         var body: some View {
+    ///             Button("View Settings") {
+    ///                 showSettings = true
+    ///             }
+    ///             .sheet(isPresented: $showSettings) {
+    ///                 SettingsView()
+    ///                     .backport.presentationBackground {
+    ///                         Color.yellow
+    ///                     }
+    ///             }
+    ///         }
+    ///     }
+    ///
+    /// A presentation background automatically fills the entire presentation and,
+    /// where supported, lets views behind the presentation show through translucent
+    /// styles.
+    ///
+    /// - Parameters:
+    ///   - alignment: The alignment that the modifier uses to position the
+    ///     implicit `ZStack` that groups the background views. The default is
+    ///     `center`.
+    ///   - content: The view to use as the background of the presentation.
+    @ViewBuilder
+    @available(iOS, introduced: 15, deprecated: 16.4, message: "Presentation background is supported natively on iOS 16.4+")
+    func presentationBackground<V: View>(
+        alignment: Alignment = .center,
+        @ViewBuilder content: () -> V
+    ) -> some View {
+        #if os(iOS)
+        if #available(iOS 16.4, *) {
+            wrapped.presentationBackground(alignment: alignment, content: content)
+        } else {
+            wrapped
+                .background(alignment: alignment) {
+                    content().ignoresSafeArea()
+                }
+                .background(BackgroundClearer())
+        }
+        #else
+        wrapped
+        #endif
+    }
+}

--- a/Sources/SwiftUIBackports/iOS/PresentationBackground/BackgroundClearer.swift
+++ b/Sources/SwiftUIBackports/iOS/PresentationBackground/BackgroundClearer.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+#if os(iOS)
+
+/// Clears the background color of the enclosing `UIHostingController`'s view so
+/// that a SwiftUI-provided background renders through.
+///
+/// Only acts when the hosting controller is actually being presented modally,
+/// guarding against accidentally clearing the background of the application's
+/// root host. Idempotent: re-applies on `updateUIView` and `didMoveToWindow`,
+/// so any subsequent system re-paint (e.g. after a trait collection change) is
+/// undone.
+@available(iOS 15, *)
+struct BackgroundClearer: UIViewRepresentable {
+    func makeUIView(context: Context) -> BackgroundClearingView {
+        BackgroundClearingView()
+    }
+
+    func updateUIView(_ uiView: BackgroundClearingView, context: Context) {
+        uiView.clearHostBackground()
+    }
+}
+
+#endif

--- a/Sources/SwiftUIBackports/iOS/PresentationBackground/BackgroundClearingView.swift
+++ b/Sources/SwiftUIBackports/iOS/PresentationBackground/BackgroundClearingView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+#if os(iOS)
+
+@available(iOS 15, *)
+final class BackgroundClearingView: UIView {
+    init() {
+        super.init(frame: .zero)
+        isHidden = true
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        clearHostBackground()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        clearHostBackground()
+    }
+
+    func clearHostBackground() {
+        // Walk the responder chain to find the first enclosing UIHostingController.
+        // The host controller's view carries the system-provided background that
+        // we want to replace; SwiftUI lays our own `.background` modifier *behind*
+        // the content but *in front* of the host's view, so clearing the host's
+        // background is what makes the supplied style visible.
+        var controller: UIViewController? = parentController
+        while let candidate = controller {
+            // `UIHostingController` is generic (`UIHostingController<Content>`) and
+            // Swift generics are invariant, so there is no `is` / `as?` form that
+            // matches "any specialisation" of it: `is UIHostingController` fails
+            // to compile (the Content parameter cannot be inferred), and
+            // `as? UIHostingController<Any>` / `as? UIHostingController<AnyView>`
+            // only match that exact specialisation. There is also no public
+            // non-generic base class or protocol to test against. Name-based
+            // identification via the Objective-C class name is the standard
+            // workaround used by UIKit-bridge libraries in the SwiftUI ecosystem.
+            if NSStringFromClass(type(of: candidate)).contains("UIHostingController") {
+                // Only clear when the host is actually being presented as a modal,
+                // so we never accidentally make the application's root host
+                // transparent.
+                if candidate.presentingViewController != nil {
+                    candidate.view.backgroundColor = .clear
+                    candidate.view.isOpaque = false
+                }
+                return
+            }
+            controller = candidate.parent
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Adds `Backport.presentationBackground(_:)` and `Backport.presentationBackground(alignment:content:)` matching Apple's iOS 16.4+ API.

```swift
.sheet(isPresented: $showSettings) {
    SettingsView()
        .backport.presentationBackground(.thickMaterial)
        // or:
        .backport.presentationBackground { Color.yellow }
}
```

- On iOS 16.4+ both overloads forward directly to the native modifier.
- On iOS 15–16.3 they layer the supplied `ShapeStyle` / custom view behind the wrapped content using SwiftUI's regular `.background`, and clear the enclosing `UIHostingController`'s `view.backgroundColor` so the system-provided `systemBackground` doesn't paint over it.

Re-submission of the closed [#81](https://github.com/shaps80/SwiftUIBackports/pull/81) / [#83](https://github.com/shaps80/SwiftUIBackports/pull/83). Both previous attempts were closed by me — #83 was a combined PR that bundled this feature with the unrelated `.height` / `.fraction` detents from #82, which muddled the review surface. This PR is the single focused presentationBackground feature only.

## Background-clearer design (why it isn't just `superview?.backgroundColor = .clear`)

The hosting `UIHostingController` is what carries the system-provided background, but it isn't the direct superview of the SwiftUI content — SwiftUI interposes its own host-view chain between content and host controller, and that chain shifts across iOS minor versions.

So the helper walks the responder chain via the existing `UIView.parentController` helper and identifies the hosting controller by Objective-C class name through `NSStringFromClass`:

```swift
while let candidate = controller {
    if NSStringFromClass(type(of: candidate)).contains("UIHostingController") {
        if candidate.presentingViewController != nil {
            candidate.view.backgroundColor = .clear
            candidate.view.isOpaque = false
        }
        return
    }
    controller = candidate.parent
}
```

`UIHostingController` is generic (`UIHostingController<Content>`) and Swift generics are invariant — `is UIHostingController` doesn't compile because the `Content` parameter can't be inferred, and `as? UIHostingController<Any>` / `<AnyView>` only match that exact specialisation. There's also no public non-generic base class or protocol to test against. Name-based identification is the standard workaround used by UIKit-bridge libraries in the SwiftUI ecosystem.

Two guard rails:

1. `presentingViewController != nil` — the modifier never accidentally makes the application's root host transparent if applied outside a modal context.
2. `updateUIView` + `didMoveToWindow` + `traitCollectionDidChange` all re-apply the clear — robust against system re-paints (e.g. trait collection change after rotation).

## Deprecation surface

The native API exists on iOS 16.4+ / tvOS 16.4+ / macOS 13.3+ / watchOS 9.4+, so the public extension carries:

```swift
@available(iOS, deprecated: 16.4)
@available(tvOS, deprecated: 16.4)
@available(macOS, deprecated: 13.3)
@available(watchOS, deprecated: 9.4)
public extension Backport where Wrapped: View { … }
```

— consumers get a migration nudge when their deployment target rises above the polyfill threshold. Matches the existing repo convention.

On non-iOS platforms the body is `wrapped` (no-op), also matching the existing repo pattern for iOS-only fallbacks behind a cross-platform `Backport.*` namespace.

## File layout

Three files under directories matching their actual platform scope:

| File | Scope | Role |
|---|---|---|
| `Sources/SwiftUIBackports/Shared/PresentationBackground/PresentationBackground.swift` | cross-platform | public modifier overloads (the iOS 15-16.3 body is wrapped in `#if os(iOS)`) |
| `Sources/SwiftUIBackports/iOS/PresentationBackground/BackgroundClearer.swift` | iOS-only | internal `UIViewRepresentable` host |
| `Sources/SwiftUIBackports/iOS/PresentationBackground/BackgroundClearingView.swift` | iOS-only | internal `UIView` subclass |

Layout mirrors the existing repo norm of grouping a feature under its own subdirectory (`iOS/Detents/`, `Shared/Tasks/`, …) and matches each file's actual platform scope rather than co-locating them all under `iOS/Presentation/`.

## Testing

Build-tested locally in a downstream consumer (`laconicman/SwiftUIPlus`'s `BottomActionSheet`, which uses `.backport.presentationBackground(.clear)` on iOS 15-16.3 to clear the cover host). Confirmed:

- iOS 15.x / 16.0-16.3: supplied `ShapeStyle` / custom view paints behind the modal, no `systemBackground` bleed.
- iOS 16.4+: forwards to native, no observable difference vs. plain `.presentationBackground(...)` call.
- macOS / tvOS / watchOS: compiles, no-ops.

The fork has carried this code in production for several iterations now (downstream `laconicman/SwiftUIPlus@2.10.0`) without regression.

