### PR TITLE
FIX: PresentationDetent.< violates Comparable irreflexivity

### DIFF
--- a/Sources/SwiftUIBackports/iOS/Presentation/Detents.swift
+++ b/Sources/SwiftUIBackports/iOS/Presentation/Detents.swift
@@ -122,10 +122,10 @@ public extension Backport<Any> {
 
         public static func < (lhs: PresentationDetent, rhs: PresentationDetent) -> Bool {
             switch (lhs, rhs) {
-            case (.large, .medium):
-                return false
-            default:
+            case (.medium, .large):
                 return true
+            default:
+                return false
             }
         }
     }


### PR DESCRIPTION
## Summary

`Backport<Any>.PresentationDetent.<` violates `Comparable`'s irreflexivity requirement (`!(x < x)`). The current implementation is:

```swift
public static func < (lhs: PresentationDetent, rhs: PresentationDetent) -> Bool {
    switch (lhs, rhs) {
    case (.large, .medium):
        return false
    default:
        return true
    }
}
```

The `default:` branch returns `true` for every non-`(.large, .medium)` input — including `(.medium, .medium)` and `(.large, .large)`. So `lhs < lhs == true` for every detent, which breaks the standard-library guarantee `Comparable` types are supposed to provide, and breaks the derived operators `==` / `>=` / `>` that the synthesised `Comparable` extension layers on top of `<`.

### Why this matters — real user-visible regression

`Backport.Representable.Controller.update(detents:selection:)` does

```swift
controller.presentingViewController.view?.tintAdjustmentMode =
    (selection?.wrappedValue ?? .large) >= .init(id: .init(rawValue: undimmed.rawValue))
    ? .automatic : .normal
```

When `selection` equals `largestUndimmedDetentIdentifier` (e.g. both are `.medium`), the comparison `medium >= medium` is synthesised as `!(medium < medium)` — which with today's `<` evaluates to `!true == false`. So at the exact threshold detent (where the presenting view *should* return to `.automatic` tint adjustment), it instead stays `.normal` (dimmed/tint-adjusted).

### Fix

Flip the switch so only `(.medium, .large)` returns `true` and everything else — including reflexive comparisons — returns `false`:

```swift
public static func < (lhs: PresentationDetent, rhs: PresentationDetent) -> Bool {
    switch (lhs, rhs) {
    case (.medium, .large):
        return true
    default:
        return false
    }
}
```

### Net effect on call sites

| Comparison | Before | After |
|---|---|---|
| `Set([.medium, .large]).sorted()` | `[.medium, .large]` | `[.medium, .large]` (unchanged) |
| `medium >= medium` | `false` ❌ | `true` ✅ |
| `large  >= large`  | `false` ❌ | `true` ✅ |
| `medium >= large`  | `false` ✅ | `false` ✅ |
| `large  >= medium` | `true`  ✅ | `true`  ✅ |

Pure correctness fix — no public API change, no behaviour change on the existing two-element sort path, but the threshold-detent tint-adjustment regression goes away.

### Related

Split out of #82 per [your suggestion in that thread](https://github.com/shaps80/SwiftUIBackports/pull/82) — keeps this defensible bug fix decoupled from the (more contentious) `.height/.fraction` namespace-completeness conversation.
